### PR TITLE
Fix typo on regex test for svg

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = (webpackConfigEnv, options) => {
       rules: [
         {
           /* Loads svg images. */
-          test: /[/\/]assets[/\/]images[/\/].+\.svg$/,
+          test: /[/\\]assets[/\\]images[/\\].+\.svg$/,
           exclude: /node_modules/,
           loader: 'file-loader',
           options: {


### PR DESCRIPTION
Regex test not working properly on OS where path separator is '\\' like windows