### PR TITLE
PROD-1583 support typescript redo -> dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
+    "@babel/preset-typescript": "^7.16.7",
     "@babel/runtime": "^7.8.7",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^9.4.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "strictNullChecks": true,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "typeRoots": [
+            "./types",
+            "./node_modules/@types"
+        ]
+    },
+    "include": [
+        "src"
+    ],
+    "exclude": [
+        "**/*.test.*"
+    ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,177 @@
+{
+    "extends": "tslint:latest",
+    "files": [],
+    "compilerOptions": {
+        "jsx": "react",
+        "declarationDir": "dist"
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "src/**/*.test*"
+    ],
+    "rules": {
+        "array-type": [
+            true,
+            "generic"
+        ],
+        "arrow-return-shorthand": true,
+        "callable-types": true,
+        "class-name": true,
+        "comment-format": [
+            true,
+            "check-space"
+        ],
+        "curly": true,
+        "cyclomatic-complexity": [
+            true,
+            7
+        ],
+        "deprecation": {
+            "severity": "none"
+        },
+        "eofline": true,
+        "forin": true,
+        "import-blacklist": [
+            true,
+            "rxjs/Rx"
+        ],
+        "import-spacing": true,
+        "indent": [
+            true,
+            "spaces",
+            4
+        ],
+        "interface-over-type-literal": true,
+        "label-position": true,
+        "max-classes-per-file": [
+            true,
+            1
+        ],
+        "max-line-length": false,
+        "member-access": false,
+        "member-ordering": [
+            true,
+            {
+                "alphabetize": true,
+                "order": [
+                    "private-static-field",
+                    "private-instance-field",
+                    "private-static-accessor",
+                    "private-instance-accessor",
+                    "public-static-field",
+                    "public-instance-field",
+                    "public-static-accessor",
+                    "public-instance-accessor",
+                    "public-constructor",
+                    "private-constructor",
+                    "public-instance-method",
+                    "private-instance-method"
+                ]
+            }
+        ],
+        "no-arg": true,
+        "no-bitwise": true,
+        "no-consecutive-blank-lines": true,
+        "no-console": true,
+        "no-construct": true,
+        "no-debugger": true,
+        "no-duplicate-super": true,
+        "no-empty": false,
+        "no-empty-interface": true,
+        "no-eval": true,
+        "no-implicit-dependencies": [
+            true,
+            "dev"
+        ],
+        "no-inferrable-types": [
+            false,
+            "ignore-params"
+        ],
+        "no-misused-new": true,
+        "no-null-keyword": true,
+        "no-non-null-assertion": true,
+        "no-shadowed-variable": true,
+        "no-string-literal": false,
+        "no-string-throw": true,
+        "no-submodule-imports": [
+            true,
+            "@heroicons"
+        ],
+        "no-switch-case-fall-through": true,
+        "no-trailing-whitespace": true,
+        "no-unnecessary-initializer": true,
+        "no-unused-expression": true,
+        "no-var-keyword": true,
+        "object-literal-sort-keys": true,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-catch",
+            "check-else",
+            "check-whitespace"
+        ],
+        "ordered-imports": [
+            true,
+            {
+                "grouped-imports": true
+            }
+        ],
+        "prefer-const": true,
+        "quotemark": [
+            true,
+            "single"
+        ],
+        "radix": true,
+        "semicolon": [
+            true,
+            "never"
+        ],
+        "trailing-comma": [
+            true,
+            {
+                "multiline": {
+                    "objects": "always",
+                    "arrays": "always",
+                    "typeLiterals": "ignore"
+                },
+                "esSpecCompliant": true
+            }
+        ],
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "typedef": [
+            true,
+            "call-signature",
+            "parameter",
+            "property-declaration",
+            "variable-declaration",
+            "member-variable-declaration",
+            "object-destructuring",
+            "array-destructuring"
+        ],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
+        ],
+        "unified-signatures": true,
+        "variable-name": false,
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,6 +89,14 @@ module.exports = (webpackConfigEnv, options) => {
             },
           ],
         },
+        {
+          test: /\.(js|jsx|ts|tsx)$/,
+          exclude: /(node_modules|bower_components)/,
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/env", "@babel/preset-react", "@babel/preset-typescript"]
+          }
+        },
       ],
     },
     plugins: [
@@ -110,6 +118,7 @@ module.exports = (webpackConfigEnv, options) => {
           "node_modules/handlebars/dist/handlebars.min.js"
         ),
       },
+      extensions: [".ts", ".tsx", ".js", ".jsx"],
       symlinks: false,
     },
     devServer: {


### PR DESCRIPTION
This recreates the PR for supporting typescript: https://topcoder.atlassian.net/browse/PROD-1583

Here's the original PR: https://github.com/topcoder-platform/mfe-customer-work/pull/270/files

mfe-core branch = master
mfe-customer-work branch = PROD-1583_typescript-redo